### PR TITLE
Added margins to UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@
 *~
 # vim
 .*.swp
-# xemacs
+# emacs
 *.flc
+\#*\#
+.\#*
 # MacOS
 .DS_Store
 # Windows

--- a/buttleofx/gui/browser/qml/FileInfo.qml
+++ b/buttleofx/gui/browser/qml/FileInfo.qml
@@ -97,6 +97,9 @@ ApplicationWindow {
                                     text: currentFile.fileName
                                     width: parent.width - 10
                                     height: parent.height
+                                    anchors.horizontalCenter: parent.horizontalCenter
+                                    anchors.top: parent.top
+                                    anchors.topMargin: 2.5
                                     maximumLength: 100
                                     selectByMouse : true
                                     color: activeFocus ? activeFocusOn : activeFocusOff

--- a/buttleofx/gui/browser/qml/FooterBar.qml
+++ b/buttleofx/gui/browser/qml/FooterBar.qml
@@ -50,6 +50,8 @@ Rectangle {
 			id: openButton
             text: "Import"
             height: parent.height - 5
+            anchors.right: parent.right
+            anchors.rightMargin: 5
 			
 			// import selected files in the graph
             onClicked: {

--- a/buttleofx/gui/browser/qml/HeaderBar.qml
+++ b/buttleofx/gui/browser/qml/HeaderBar.qml
@@ -298,6 +298,9 @@ Rectangle {
 
         CheckBox {
             id: check
+            anchors.right: parent.right
+            anchors.rightMargin: 5
+
             style: CheckBoxStyle {
                 label: Text {
                     text: "Seq"

--- a/buttleofx/gui/browser/qml/WindowFiles.qml
+++ b/buttleofx/gui/browser/qml/WindowFiles.qml
@@ -63,7 +63,7 @@ Rectangle {
 
     function forceActiveFocusOnRefresh() {
         fileModel.updateFileItems(fileModel.folder)
-        winFile.selectItem(0)
+        winFile.selectItem(itemIndex)
     }
     function forceActiveFocusOnChangeIndexOnRight() {
         if(itemIndex < fileModel.size) {

--- a/buttleofx/gui/browser/qml/WindowFiles.qml
+++ b/buttleofx/gui/browser/qml/WindowFiles.qml
@@ -558,6 +558,8 @@ Rectangle {
 
                         Text {
                             id: textInRow
+                            anchors.top: parent.top
+                            anchors.topMargin: 5
                             x: 10
 
                             text: model.object.fileName


### PR DESCRIPTION
Hi there,
I made a few small changes to add margins to some buttons at the ends of the file browser header + footer, and also to center the filenames in the context menus. I also added a few more patterns in .gitignore for Emacs.
