### PR TITLE
Added hotkey for the file browser to enter the selected folder

### DIFF
--- a/buttleofx/gui/browser/fileModelBrowser.py
+++ b/buttleofx/gui/browser/fileModelBrowser.py
@@ -30,6 +30,7 @@ class FileItem(QtCore.QObject):
         else:
             self._filepath = folder + "/" + fileName
         self._fileType = fileType
+        self._isSupported = supported
         
         if fileType == FileItem.Type.File:
             if supported:
@@ -38,8 +39,7 @@ class FileItem(QtCore.QObject):
                 self._fileImg = "../../img/buttons/browser/file-icon.png"
             self._seq = None
             self._fileWeight = os.stat(self._filepath).st_size
-            (_, extension) = os.path.splitext(fileName)
-            self._fileExtension = extension
+            self._fileExtension = os.path.splitext(fileName)[1]
         
         elif fileType == FileItem.Type.Folder:
             self._fileImg = "../../img/buttons/browser/folder-icon.png"
@@ -122,6 +122,10 @@ class FileItem(QtCore.QObject):
     
     def getSequence(self):
         return self._seq
+
+    @QtCore.pyqtSlot(result=bool)
+    def getSupported(self):
+        return self._isSupported
 
     filepath = QtCore.pyqtProperty(str, getFilepath, setFilepath, constant=True)
     fileType = QtCore.pyqtProperty(str, getFileType, constant=True)

--- a/buttleofx/gui/browser/fileModelBrowser.py
+++ b/buttleofx/gui/browser/fileModelBrowser.py
@@ -64,14 +64,16 @@ class FileItem(QtCore.QObject):
             self._fileWeight = self._seq.getWeight()
             (_, extension) = os.path.splitext(seqPath)
             self._fileExtension = extension
-           
+
+    @QtCore.pyqtSlot(result=str)
     def getFilepath(self):
         return self._filepath
     
     def setFilepath(self, newpath):
         import shutil
         shutil.move(self.filepath, newpath + "/" + self.fileName)
-    
+ 
+    @QtCore.pyqtSlot(result=str)
     def getFileType(self):
         return self._fileType
     
@@ -141,6 +143,7 @@ class FileModelBrowser(QtQuick.QQuickItem):
     
     _folder = ""
     _firstFolder = ""
+    _lastSelected = _firstFolder
     
     def __init__(self, parent=None):
         super(FileModelBrowser, self).__init__(parent)
@@ -286,7 +289,12 @@ class FileModelBrowser(QtQuick.QQuickItem):
                 selectedList.append(item)
 
         return selectedList
-    
+
+    @QtCore.pyqtSlot(result=QtCore.QObject)
+    def getLastSelected(self):
+        return self._lastSelected
+
+    @QtCore.pyqtSlot(result=QtCore.QObject)    
     def getFileItems(self):
         return self._fileItemsModel
     
@@ -296,6 +304,7 @@ class FileModelBrowser(QtQuick.QQuickItem):
             item.isSelected = False
         if index < len(self._fileItems):
             self._fileItems[index].isSelected = True
+            self._lastSelected = self._fileItems[index]
 
     @QtCore.pyqtSlot(int)
     def selectItems(self, index):

--- a/buttleofx/gui/browser/qml/Browser.qml
+++ b/buttleofx/gui/browser/qml/Browser.qml
@@ -26,7 +26,7 @@ Rectangle {
         id: listPrevious
     }
 
-    FileModelBrowser{
+    FileModelBrowser {
         id: firstFile
     }
 
@@ -113,11 +113,16 @@ Rectangle {
 
 
     Keys.onPressed: {
+        if ((event.key == Qt.Key_Tab)) {
+            headerBar.forceActiveFocusOnPathWithTab()
+            event.accepted = true
+        }
+        if ((event.key == Qt.Key_Return)) {
+            files.enterFolder()
+            event.accepted = true
+        }
         if ((event.key == Qt.Key_L) && (event.modifiers & Qt.ControlModifier)) {
             headerBar.forceActiveFocusOnPath()
-            event.accepted = true
-        }if ((event.key == Qt.Key_Tab)) {
-            headerBar.forceActiveFocusOnPathWithTab()
             event.accepted = true
         }
         if ((event.key == Qt.Key_N) && (event.modifiers & Qt.ControlModifier)) {

--- a/buttleofx/gui/browser/qml/HeaderBar.qml
+++ b/buttleofx/gui/browser/qml/HeaderBar.qml
@@ -23,6 +23,7 @@ Rectangle {
         withTab = false
         texteditPath.forceActiveFocus()
     }
+
     function forceActiveFocusOnPathWithTab() {
         withTab = true
         texteditPath.forceActiveFocus()

--- a/buttleofx/gui/browser/qml/WindowFiles.qml
+++ b/buttleofx/gui/browser/qml/WindowFiles.qml
@@ -22,20 +22,28 @@ Rectangle {
     property bool showSeq: false
     property int nbCell: viewList ? 1 : gridview.width/gridview.cellWidth
 
-    function showEditFile(pos)
-    {
+    function showEditFile(pos) {
         fileInfo.visible = true
         fileInfo.x = mainWindowQML.x + pos.x - 5
         fileInfo.y = mainWindowQML.y + pos.y - 5
     }
 
+    function enterFolder() {
+        var lastSelected = fileModel.getLastSelected()
+        if (lastSelected.getFileType() == 'Folder') {
+            winFile.goToFolder(lastSelected.getFilepath())
+        }
+    }
+
     function forceActiveFocusOnCreate() {
         fileModel.createFolder(fileModel.folder + "/New Directory")
     }
+
     function forceActiveFocusOnDelete() {
         fileModel.deleteItem(itemIndex)
         winFile.forceActiveFocusOnRefresh()
     }
+
     function selectItem(index){
         fileModel.selectItem(index)
         var sel = fileModel.getSelectedItems()
@@ -65,11 +73,13 @@ Rectangle {
         fileModel.updateFileItems(fileModel.folder)
         winFile.selectItem(0)
     }
+
     function forceActiveFocusOnChangeIndexOnRight() {
         if(itemIndex < fileModel.size) {
             winFile.selectItem(++itemIndex)
         }
     }
+
     function forceActiveFocusOnChangeIndexOnLeft() {
         if(itemIndex > 0) {
             winFile.selectItem(--itemIndex)
@@ -145,6 +155,7 @@ Rectangle {
             itemIndex = 0
         }
     }
+
     FileInfo {
         id: fileInfo
         visible: false
@@ -166,6 +177,7 @@ Rectangle {
         }
     }
 
+    // Code for the (default) grid  layout
     ScrollView {
         anchors.fill: parent
         anchors.topMargin: 5
@@ -460,6 +472,7 @@ Rectangle {
         }
     }
 
+    // Code for the list layout
     ScrollView {
         anchors.fill: parent
         anchors.topMargin: 5
@@ -601,20 +614,20 @@ Rectangle {
                             fileInfo.currentFile = fileModel.getSelectedItems() ? fileModel.getSelectedItems().get(0) : undefined
 
                             //if shift:
-                            if(mouse.modifiers & Qt.ShiftModifier)
+                            if (mouse.modifiers & Qt.ShiftModifier)
                                 fileModel.selectItemsByShift(listview.previousIndex, index)
 
                             listview.previousIndex = index
                             //if ctrl:
-                            if(mouse.modifiers & Qt.ControlModifier)
+                            if (mouse.modifiers & Qt.ControlModifier)
                                 fileModel.selectItems(index)
 
-                            else if(!(mouse.modifiers & Qt.ShiftModifier))
+                            else if (!(mouse.modifiers & Qt.ShiftModifier))
                                 fileModel.selectItem(index)
 
                             var sel = fileModel.getSelectedItems()
                             var selection = new Array()
-                            for(var selIndex = 0; selIndex < sel.count; ++selIndex)
+                            for (var selIndex = 0; selIndex < sel.count; ++selIndex)
                             {
                                 selection[selIndex] = sel.get(selIndex).filepath
                             }
@@ -622,23 +635,23 @@ Rectangle {
                             winFile.changeSelectedList(sel)
 
                             // if it's an image, we assign it to the viewer
-                             if (model.object.fileType != "Folder") {
-                                 player.changeViewer(11) // we come to the temporary viewer
-                                 // we save the last node wrapper of the last view
-                                 player.lastNodeWrapper = _buttleData.getNodeWrapperByViewerIndex(player.lastView)
+                            if (model.object.fileType != "Folder") {
+                                player.changeViewer(11) // we come to the temporary viewer
+                                // we save the last node wrapper of the last view
+                                player.lastNodeWrapper = _buttleData.getNodeWrapperByViewerIndex(player.lastView)
 
-                                 readerNode.nodeWrapper = _buttleData.nodeReaderWrapperForBrowser(model.object.filepath)
+                                readerNode.nodeWrapper = _buttleData.nodeReaderWrapperForBrowser(model.object.filepath)
 
-                                 _buttleData.currentGraphIsGraphBrowser()
-                                 _buttleData.currentGraphWrapper = _buttleData.graphBrowserWrapper
+                                _buttleData.currentGraphIsGraphBrowser()
+                                _buttleData.currentGraphWrapper = _buttleData.graphBrowserWrapper
 
-                                 _buttleData.currentViewerNodeWrapper = readerNode.nodeWrapper
-                                 _buttleData.currentViewerFrame = 0
-                                 // we assign the node to the viewer, at the frame 0
-                                 _buttleData.assignNodeToViewerIndex(readerNode.nodeWrapper, 10)
-                                 _buttleData.currentViewerIndex = 10 // we assign to the viewer the 10th view
-                                 _buttleEvent.emitViewerChangedSignal()
-                             }
+                                _buttleData.currentViewerNodeWrapper = readerNode.nodeWrapper
+                                _buttleData.currentViewerFrame = 0
+                                // we assign the node to the viewer, at the frame 0
+                                _buttleData.assignNodeToViewerIndex(readerNode.nodeWrapper, 10)
+                                _buttleData.currentViewerIndex = 10 // we assign to the viewer the 10th view
+                                _buttleEvent.emitViewerChangedSignal()
+                            }
                         }
 
                         onDoubleClicked: {

--- a/buttleofx/gui/browser/qml/WindowFiles.qml
+++ b/buttleofx/gui/browser/qml/WindowFiles.qml
@@ -49,7 +49,7 @@ Rectangle {
         var sel = fileModel.getSelectedItems()
         // if it's an image, we assign it to the viewer
         if(sel && !sel.isEmpty()){
-            if (sel.get(0).fileType != "Folder") {
+            if (sel.get(0).fileType != "Folder" && sel.get(0).getSupported()) {
                 player.changeViewer(11) // we come to the temporary viewer
                 // we save the last node wrapper of the last view
                 player.lastNodeWrapper = _buttleData.getNodeWrapperByViewerIndex(player.lastView)


### PR DESCRIPTION
Hi there,
This patch lets the user enter the selected folder when they press the enter key.
It works like this:
- FileModelBrowser.py has a new variable ,`_lastSelected`, that holds the FileItem of the last selected item. It also has a new getter method ,`getLastSelected()`, that returns `_lastSelected`. I added a line to `selectItem()` to update `_lastSelected` on each selection change. `FileItem.getFilepath()` and `FileItem.getFileType()` are exposed to QML as well.
- There's a new function in WindowFiles.qml (imaginatively named `enterFolder` :P) that will get `_lastSelected` and enter it if it is a folder.
- There's a new case in Browser.qml to catch when the enter key is pressed, this just calls `enterFolder()`.

If there are multiple items selected, the browser will enter the last selected item (as long as it is a folder of course). There's also a bit of whitespace cleanup.

C&C is welcome, I'm happy to implement it differently if this is a bit messy or something :)
