### PR TITLE
Improvements to the browser context menu

### DIFF
--- a/buttleofx/gui/browser/fileModelBrowser.py
+++ b/buttleofx/gui/browser/fileModelBrowser.py
@@ -103,9 +103,6 @@ class FileItem(QtCore.QObject):
     def getFileImg(self):
         return self._fileImg
 
-    def getFileExtension(self):
-        return self._fileExtension
-
     def getFileName(self):
         return os.path.basename(self._filepath)
 
@@ -144,7 +141,6 @@ class FileItem(QtCore.QObject):
     fileType = QtCore.pyqtProperty(str, getFileType, constant=True)
     fileName = QtCore.pyqtProperty(str, getFileName, setFileName, constant=True)
     fileWeight = QtCore.pyqtProperty(float, getFileWeight, constant=True)
-    fileExtension = QtCore.pyqtProperty(str, getFileExtension, constant=True)
 
     imageSize = QtCore.pyqtProperty(QtCore.QSize, getImageSize, constant=True)
     isSelectedChange = QtCore.pyqtSignal()

--- a/buttleofx/gui/browser/qml/FileInfo.qml
+++ b/buttleofx/gui/browser/qml/FileInfo.qml
@@ -141,33 +141,6 @@ ApplicationWindow {
                                 width: parent.width
                                 implicitHeight: childrenRect.height
 
-                                // Extension of file
-                                RowLayout {
-                                    id: fieExtensionContainer
-                                    spacing: 5
-                                    width: parent.width
-                                    implicitHeight: childrenRect.height
-
-                                    Text {
-                                        id: fileExtensionText
-                                        color: textColor
-                                        text: "Extension: "
-                                    }
-
-                                    Rectangle {
-                                        height: 20
-                                        implicitWidth: 200
-                                        clip: true
-                                        color: "transparent"
-
-                                        Text {
-                                            id: fileExtensionInput
-                                            text: currentFile.fileExtension
-                                            color: "grey"
-                                        }
-                                    }
-                                }
-
                                 // Weight of file
                                 RowLayout {
                                     id: fileWeight

--- a/buttleofx/gui/browser/qml/FileInfo.qml
+++ b/buttleofx/gui/browser/qml/FileInfo.qml
@@ -128,51 +128,30 @@ ApplicationWindow {
                     Rectangle {
                         id: fileDetailedInfoContainer
                         width: parent.width
-                        implicitHeight: fileDetailedInfoLoader.childrenRect.height
+                        implicitHeight: fileSizeInfoLoader.childrenRect.height + imageDimensionsLoader.childrenRect.height
 
-                        Loader {
-                            id: fileDetailedInfoLoader
-                            sourceComponent: currentFile.fileType != 'Folder' ? fileDetailedInfo : undefined
-                        }
+                        ColumnLayout {
+                            width: parent.width
+                            implicitHeight: childrenRect.height
 
-                        Component {
-                            id: fileDetailedInfo
-                            ColumnLayout {
-                                width: parent.width
-                                implicitHeight: childrenRect.height
+                            Loader {
+                                id: fileSizeInfoLoader
+                                sourceComponent: currentFile.fileType != 'Folder' ? fileSizeInfo : undefined
+                            }
 
-                                // Weight of file
-                                RowLayout {
-                                    id: fileWeight
-                                    width: parent.width
-                                    implicitHeight: childrenRect.height
+                            Loader {
+                                id: imageDimensionsLoader
+                                sourceComponent: (currentFile.fileType != 'Folder' && currentFile.getSupported() ?
+                                                  imageDimensionsInfo : undefined)
+                            }
 
-                                    Text {
-                                        id: fileWeightText
-                                        color: textColor
-                                        text: "Weight: "
-                                    }
+                            Component {
+                                id: fileSizeInfo
 
-                                    Rectangle {
-                                        height: 20
-                                        implicitWidth: 200
-                                        clip: true
-                                        color: "transparent"
-
-                                        Text {
-                                            id: fileWeightInput
-                                            text: (currentFile.fileWeight > 1000000 ? (currentFile.fileWeight/1000000).toFixed(2)
-                                                   + " Mo" : (currentFile.fileWeight/1000).toFixed(2) + " Ko")
-                                            color: "grey"
-                                        }
-                                    }
-                                }
-
-                                // Size of File
+                                // Size of file
                                 RowLayout {
                                     id: fileSize
                                     width: parent.width
-                                    implicitHeight: childrenRect.height
 
                                     Text {
                                         id: fileSizeText
@@ -180,18 +159,34 @@ ApplicationWindow {
                                         text: "Size: "
                                     }
 
-                                    Rectangle {
-                                        height: 20
-                                        implicitWidth: 200
-                                        clip: true
-                                        color: "transparent"
+                                    Text {
+                                        id: fileSizeInput
+                                        text: (currentFile.fileWeight > 1000000 ? (currentFile.fileWeight / 1000000).toFixed(2)
+                                               + " MB" : (currentFile.fileWeight / 1000).toFixed(2) + " KB")
+                                        color: "grey"
+                                    }
+                                }
+                            }
 
-                                        Text {
-                                            id: fileSizeInput
-                                            property size imageSize: currentFile.imageSize
-                                            text: "width: " + imageSize.width + ", height: " + imageSize.height
-                                            color: "grey"
-                                        }
+                            Component {
+                                id: imageDimensionsInfo
+
+                                // Dimensions of image (only displayed if the file is an image, of course)
+                                RowLayout {
+                                    id: imageDimensions
+                                    width: parent.width
+
+                                    Text {
+                                        id: imageDimensionsText
+                                        color: textColor
+                                        text: "Dimensions: "
+                                    }
+
+                                    Text {
+                                        id: imageDimensionsInput
+                                        property size imageDimensions: currentFile.imageSize
+                                        text: "width: " + imageDimensions.width + ", height: " + imageDimensions.height
+                                        color: "grey"
                                     }
                                 }
                             }
@@ -199,17 +194,15 @@ ApplicationWindow {
                     }
 
                     Item {
-                        id:remove
+                        id: remove
                         width: parent.width
                         implicitHeight: 30
                         Layout.minimumHeight: 20
 
                         Button {
                             id: removeButton
-
                             height: parent.height - 10
                             width: 200
-
                             text: "Remove"
 
                             onClicked: {

--- a/buttleofx/gui/browser/qml/WindowFiles.qml
+++ b/buttleofx/gui/browser/qml/WindowFiles.qml
@@ -344,7 +344,7 @@ Rectangle {
                             winFile.changeSelectedList(sel)
 
                             // If it's an image, we assign it to the viewer
-                            if (model.object.fileType != "Folder") {
+                            if (model.object.fileType != "Folder" && model.object.getSupported()) {
                                 player.changeViewer(11) // We come to the temporary viewer
                                 // We save the last node wrapper of the last view
                                 player.lastNodeWrapper = _buttleData.getNodeWrapperByViewerIndex(player.lastView)
@@ -364,7 +364,7 @@ Rectangle {
 
                         onDoubleClicked: {
                             // If it's an image, we create a node
-                            if (model.object.fileType != "Folder") {
+                            if (model.object.fileType != "Folder" && model.object.getSupported()) {
                                 _buttleData.currentGraphWrapper = _buttleData.graphWrapper
                                 _buttleData.currentGraphIsGraph()
 
@@ -650,7 +650,7 @@ Rectangle {
                             winFile.changeSelectedList(sel)
 
                             // If it's an image, we assign it to the viewer
-                            if (model.object.fileType != "Folder") {
+                            if (model.object.fileType != "Folder" && model.object.getSupported()) {
                                 player.changeViewer(11) // We come to the temporary viewer
                                 // We save the last node wrapper of the last view
                                 player.lastNodeWrapper = _buttleData.getNodeWrapperByViewerIndex(player.lastView)
@@ -670,7 +670,7 @@ Rectangle {
 
                         onDoubleClicked: {
                             // If it's an image, we create a node
-                            if (model.object.fileType != "Folder") {
+                            if (model.object.fileType != "Folder" && model.object.getSupported()) {
                                 _buttleData.currentGraphWrapper = _buttleData.graphWrapper
                                 _buttleData.currentGraphIsGraph()
 

--- a/buttleofx/gui/browser/qml/WindowFiles.qml
+++ b/buttleofx/gui/browser/qml/WindowFiles.qml
@@ -283,7 +283,6 @@ Rectangle {
                         }
                     }*/
 
-
                     Drag.active: rootFileItem_mouseArea.drag.active
                     Drag.hotSpot.x: 20
                     Drag.hotSpot.y: 20
@@ -378,7 +377,7 @@ Rectangle {
                                 }
 
                                 _buttleManager.nodeManager.dropFile(model.object.filepath, 10, 10)
-                            } else {
+                            } else if (model.object.fileType == "Folder") {
                                 winFile.goToFolder(model.object.filepath)
                             }
                         }
@@ -684,7 +683,7 @@ Rectangle {
                                 }
 
                                 _buttleManager.nodeManager.dropFile(model.object.filepath, 10, 10)
-                            } else {
+                            } else if (model.object.fileType == "Folder") {
                                 winFile.goToFolder(model.object.filepath)
                             }
                         }


### PR DESCRIPTION
Hi there,
I made a couple of changes to the context menu:
- Removed the extension row, it seemed unnecessary given that it's already displayed in the name row.
- Removed FileItem.getExtension() and the FileItem.imageSize property.
- Renamed the 'Weight' and 'Size' rows to 'Size' and 'Dimensions', also anglicised the filesize units from 'Ko' and 'Mo' to 'KB' and 'MB'.
- Shifted the size and dimensions QML code into components so they can be called only when necessary.
- Added some more checks to WindowFiles.qml to prevent displaying non-supported files inthe viewer.

Note: I didn't see the point of wrapping the QML Text elements in Rectangles, so I removed that. Made the alignment much nicer. If they should be kept as Rectangles, then just let me know and I'll change them back :)
